### PR TITLE
Adding config for s3_proxies to explicitly set proxy for s3 traffic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+2.0.7 (2022-11-01)
+------------------
+
+**Changes**
+  - Providing an optional s3_proxies dict config to set the use of a proxy server. Set to {} to avoid using a proxy server for s3 traffic.
+
 2.0.6 (2022-10-05)
 ------------------
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Here is an example of basic config, that's using the default Profile based authe
         "bucket": "tradesignals-crawler",
         "warning_if_no_files": false,
         "table_suffix": "_extract1",
+        "s3_proxies": {"http": "http://mickeymouse.com:3128","https": "http://mickeymouse.com:3128"},
         "tables": [{
             "search_prefix": "feeds",
             "search_pattern": ".csv",
@@ -76,8 +77,9 @@ For non-profile based authentication set `aws_access_key_id` , `aws_secret_acces
 - **aws_endpoint_url**: (Optional): The complete URL to use for the constructed client. Normally, botocore will automatically construct the appropriate URL to use when communicating with a service. You can specify a complete URL (including the "http/https" scheme) to override this behavior. For example https://nyc3.digitaloceanspaces.com
 - **start_date**: This is the datetime that the tap will use to look for newly updated or created files, based on the modified timestamp of the file.
 - **bucket**: The name of the bucket to search for files under.
-- **warning_if_no_files**: Will attempt to log a warning rather than error if there are no files found for the search criteria if the setting is set to `true`.
-- **table_suffix**: If set will append a suffix on each of the tables to provide some uniqueness e.g. a date or supplier identifier.
+- **warning_if_no_files**: (Optional): Will attempt to log a warning rather than error if there are no files found for the search criteria if the setting is set to `true`.
+- **table_suffix**: (Optional): If set will append a suffix on each of the tables to provide some uniqueness e.g. a date or supplier identifier.
+- **s3_proxies**: (Optional): A dict of proxies settings for use of a proxy server. Set to {} to avoid using a proxy server for s3 traffic.
 - **tables**: JSON object that the tap will use to search for files, and emit records as "tables" from those files. 
 
 The `table` field consists of one or more objects, that describe how to find files and emit records. A more detailed (and unescaped) example below:

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md') as f:
     long_description = f.read()
 
 setup(name='pipelinewise-tap-s3-csv',
-      version='2.0.6',
+      version='2.0.7',
       description='Singer.io tap for extracting CSV files from S3 - PipelineWise compatible',
       long_description=long_description,
       long_description_content_type='text/markdown',

--- a/tap_s3_csv/config.py
+++ b/tap_s3_csv/config.py
@@ -12,5 +12,6 @@ CONFIG_CONTRACT = Schema([{
     Optional('string_overrides'): [str],
     Optional('delimiter'): str,
     Optional('table_suffix'): str,
-    Optional('remove_character'): str
+    Optional('remove_character'): str,
+    Optional('s3_proxies'): object
 }])


### PR DESCRIPTION
## Problem

Proxy settings can be picked up by the environment variables HTTP_PROXY and HTTPS_PROXY. This however may not be appropriate for s3 traffic and you may use a S3 Gateway or S3 endpoint to keep traffic private in the AWS network.

## Proposed changes

Add a separate s3_proxies config containing a dict listing a set of proxies. To avoid using a proxy server config to an empty dict i.e. s3_proxies: {} 


## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [ ] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions