### PR TITLE
Feature/select encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ The `table` field consists of one or more objects, that describe how to find fil
 - **delimiter**: This allows you to specify a custom delimiter, such as `\t` or `|`, if that applies to your files.
 - **string_overrides**: Specifies field names in the files that should be parsed as a string regardless of what was discovered.
 - **remove_character**: Specifies a character which can be removed from each line in the the file e.g. `"\""` will remove all double-quotes.
+- **encoding**: The encoding to use to read these files from [codecs -> Standard Encodings](https://docs.python.org/3/library/codecs.html#standard-encodings)
 
 A sample configuration is available inside [config.sample.json](config.sample.json)
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(name='pipelinewise-tap-s3-csv',
           'boto3==1.24.31',
           'pipelinewise-singer-python==2.0.*',
           # Public repository
-          'singer-encodings @ git+https://github.com/s7clarke10/singer-encodings.git',
+          'singer-encodings @ git+https://github.com/mjsqu/singer-encodings.git',
           'voluptuous==0.13.1',
           'ujson==5.4.0',
           'messytables==0.15.*',

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(name='pipelinewise-tap-s3-csv',
           'boto3==1.24.31',
           'pipelinewise-singer-python==2.0.*',
           # Public repository
-          'singer-encodings @ git+https://github.com/mjsqu/singer-encodings.git',
+          'singer-encodings @ git+https://github.com/s7clarke10/singer-encodings.git',
           'voluptuous==0.13.1',
           'ujson==5.4.0',
           'messytables==0.15.*',

--- a/tap_s3_csv/config.py
+++ b/tap_s3_csv/config.py
@@ -13,5 +13,6 @@ CONFIG_CONTRACT = Schema([{
     Optional('delimiter'): str,
     Optional('table_suffix'): str,
     Optional('remove_character'): str,
-    Optional('s3_proxies'): object
+    Optional('s3_proxies'): object,
+    Optional('encoding'): str,
 }])


### PR DESCRIPTION
## Problem

The default encoding of singer-encodings can cause errors when strange characters are found:

```
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xa0 in position 75: invalid start byte
``` 

## Proposed changes

This change will add documentation on how to use the new `encoding` option. The main change to enable the encoding option is detailed in the `singer-encodings` repository, where this new option has been enabled. See this Pull Request:

https://github.com/s7clarke10/singer-encodings/pull/2

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions

## Manual QA
This was tested on local data that contained `u'\xa0'` - with the default encoding of `utf-8-sig` this caused errors:

```
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xa0 in position 75: invalid start byte
```

Adding the `encoding` option to `singer-encodings` and then providing:

```json
[
    {
        "search_prefix": "some_folder/",
        "search_pattern": "SOME_FILE_[0-9]+[.]csv",
        "table_name": "LOAD_SOME_FILE",
        "key_properties": [],
        "delimiter": ",",
        "encoding": "cp1252"
    }
]
```

Resulted in no encoding errors. 

# Risks
 - 
 
# Rollback steps
 - revert this branch
