### PR TITLE
Feature/stringify all columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ The `table` field consists of one or more objects, that describe how to find fil
 - **date_overrides**: Specifies field names in the files that are supposed to be parsed as a datetime. The tap doesn't attempt to automatically determine if a field is a datetime, so this will make it explicit in the discovered schema.
 - **delimiter**: This allows you to specify a custom delimiter, such as `\t` or `|`, if that applies to your files.
 - **string_overrides**: Specifies field names in the files that should be parsed as a string regardless of what was discovered.
+- **guess_types**: (default `True`) By default, column data types will be determined via scanning the first file in a table_spec. Set this to `False` to disable this and set all columns to `string`.
 - **remove_character**: Specifies a character which can be removed from each line in the the file e.g. `"\""` will remove all double-quotes.
 - **encoding**: The encoding to use to read these files from [codecs -> Standard Encodings](https://docs.python.org/3/library/codecs.html#standard-encodings)
 

--- a/tap_s3_csv/config.py
+++ b/tap_s3_csv/config.py
@@ -10,6 +10,7 @@ CONFIG_CONTRACT = Schema([{
     Optional('search_prefix'): str,
     Optional('date_overrides'): [str],
     Optional('string_overrides'): [str],
+    Optional('guess_types'): bool,
     Optional('delimiter'): str,
     Optional('table_suffix'): str,
     Optional('remove_character'): str,

--- a/tap_s3_csv/conversion.py
+++ b/tap_s3_csv/conversion.py
@@ -7,7 +7,9 @@ import io
 from typing import Dict, List
 from messytables import CSVTableSet, headers_guess, headers_processor, offset_processor, type_guess
 from messytables.types import DecimalType, IntegerType
+from singer import get_logger
 
+LOGGER = get_logger('tap_s3_csv')
 
 def generate_schema(samples: List[Dict], table_spec: Dict) -> Dict:
     """
@@ -53,6 +55,7 @@ def generate_schema(samples: List[Dict], table_spec: Dict) -> Dict:
                         'type': ['null', 'string']
                     }
     else:
+        LOGGER.info(f"Type guessing is turned off (guess_types is False) - all columns will be str")
         for header in headers:
             schema[header] = {
                 'type': ['null', 'string']

--- a/tap_s3_csv/conversion.py
+++ b/tap_s3_csv/conversion.py
@@ -26,32 +26,38 @@ def generate_schema(samples: List[Dict], table_spec: Dict) -> Dict:
     row_set.register_processor(headers_processor(headers))
     row_set.register_processor(offset_processor(offset + 1))
 
-    types = type_guess(row_set.sample, strict=True)
+    if table_spec.get('guess_types',True):
+        types = type_guess(row_set.sample, strict=True)
 
-    for header, header_type in zip(headers, types):
+        for header, header_type in zip(headers, types):
 
-        date_overrides = set(table_spec.get('date_overrides', []))
+            date_overrides = set(table_spec.get('date_overrides', []))
 
-        string_overrides = set(table_spec.get('string_overrides', []))
+            string_overrides = set(table_spec.get('string_overrides', []))
 
-        if header in date_overrides:
-            schema[header] = {'type': ['null', 'string'], 'format': 'date-time'}
-        elif header in string_overrides:
-            schema[header] = {'type': ['null', 'string']}
-        else:
-            if isinstance(header_type, IntegerType):
-                schema[header] = {
-                    'type': ['null', 'integer']
-                }
-            elif isinstance(header_type, DecimalType):
-                schema[header] = {
-                    'type': ['null', 'number']
-                }
+            if header in date_overrides:
+                schema[header] = {'type': ['null', 'string'], 'format': 'date-time'}
+            elif header in string_overrides:
+                schema[header] = {'type': ['null', 'string']}
             else:
-                schema[header] = {
-                    'type': ['null', 'string']
-                }
-
+                if isinstance(header_type, IntegerType):
+                    schema[header] = {
+                        'type': ['null', 'integer']
+                    }
+                elif isinstance(header_type, DecimalType):
+                    schema[header] = {
+                        'type': ['null', 'number']
+                    }
+                else:
+                    schema[header] = {
+                        'type': ['null', 'string']
+                    }
+    else:
+        for header in headers:
+            schema[header] = {
+                'type': ['null', 'string']
+            }
+    
     return schema
 
 

--- a/tap_s3_csv/s3.py
+++ b/tap_s3_csv/s3.py
@@ -84,7 +84,12 @@ def get_sampled_schema_for_table(config: Dict, table_spec: Dict) -> Dict:
     modified_since = utils.strptime_with_tz(config['start_date'])
     s3_files_gen = get_input_files_for_table(config, table_spec, modified_since)
 
-    samples = list(sample_files(config, table_spec, s3_files_gen))
+    if table_spec.get('guess_types',True):
+      samples = list(sample_files(config, table_spec, s3_files_gen))
+    else:
+      LOGGER.info('Guess Types is off - sampling for header names only')
+      samples = list(sample_files(config, table_spec, s3_files_gen,
+                 sample_rate = 1, max_records = 1, max_files = 1))
 
     if not samples:
         return {}

--- a/tests/unit/test_conversion.py
+++ b/tests/unit/test_conversion.py
@@ -51,7 +51,7 @@ class TestStringConversion(unittest.TestCase):
         }
 
         schema = generate_schema(samples, table_specs)
-
+        
         self.assertDictEqual({
             'id': {
                 'type': ['null', 'string']
@@ -73,6 +73,25 @@ class TestStringConversion(unittest.TestCase):
             }
         }, schema)
 
+class TestGuessTypes(unittest.TestCase):
+    def test_generate_schema(self):
+        samples = [
+            dict(id='1', name='productA', added_at='2017/05/18 10:40:22', price='22.99', sold='true',
+                 sold_at='2019-11-29'),
+            dict(id='4', name='productB', added_at='2017/05/18 10:40:22', price='18', sold='false'),
+            dict(id='6', name='productC', added_at='2017/05/18 10:40:22', price='14.6', sold='true',
+                 sold_at='2019-12-11'),
+        ]
+
+        table_specs = {
+            'guess_types': False
+        }
+
+        schema = generate_schema(samples, table_specs)
+        
+        want = {key:{'type': ['null', 'string']} for key in samples[0].keys()}
+        
+        self.assertDictEqual(want, schema)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Problem

Raw data provided in CSV files is prone to mistyping. A good example is telephone numbers, which can be interpreted as `str` or `integer` based on what is sampled from the data:

|tel|
|---|
|012345|
|1456|
|123 ext. 7586|

If the column above is determined to be an integer during the sampling process, then the tap breaks when row 3 is reached, because `123 ext. 7586` cannot be converted to an integer.

## Proposed changes

Add a new `table_spec` option called `guess_types` (default `true` - original behaviour). When set to `false` this does:

- Reduces sampling options to 
    - sampling rate = 1
    - max rows = 1
    - max files = 1
- Instead of trying to determine types of columns, sets all types to `['null','string']`

The reduction of sampling helps improve performance because files only need to be sampled to obtain column header names - so 1 row from one file suffices to achieve this.

## Types of changes

What types of changes does your code introduce to PipelineWise?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions