### PR TITLE
Feature/key column order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+2.0.9 (2023-05-23)
+------------------
+**Changes**
+  - Using a List rather than a Set when obtaining a unique list of columns in the spreadsheet. This
+  allows the column order to be retained as per the original csv file.
+
 2.0.8 (2022-12-22)
 ------------------
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md') as f:
     long_description = f.read()
 
 setup(name='pipelinewise-tap-s3-csv',
-      version='2.0.8',
+      version='2.0.9',
       description='Singer.io tap for extracting CSV files from S3 - PipelineWise compatible',
       long_description=long_description,
       long_description_content_type='text/markdown',

--- a/tap_s3_csv/conversion.py
+++ b/tap_s3_csv/conversion.py
@@ -72,10 +72,12 @@ def _csv2bytesio(data: List[Dict]) -> io.BytesIO:
     """
     with io.StringIO() as sio:
 
-        header = set()
+        header = []
 
+        # Create a unique list of headers
         for datum in data:
-            header.update(list(datum.keys()))
+            for item in datum:
+                header.append(item) if item not in header else None
 
         writer = csv.DictWriter(sio, fieldnames=header)
 


### PR DESCRIPTION
## Problem

Columns were not sorted in the order of the csv headers because a Set (which is unordered) was used to obtain a unique set of columns.

## Proposed changes

Change from using a Set to a List (with a conditional statement) to obtain a unique list of columns.


## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions